### PR TITLE
SOC-555: Force XML v1.1 preable to avoid parse errors.

### DIFF
--- a/.idea/libraries/Maven__com_github_rwitzel_streamflyer_streamflyer_core_1_2_0.xml
+++ b/.idea/libraries/Maven__com_github_rwitzel_streamflyer_streamflyer_core_1_2_0.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: com.github.rwitzel.streamflyer:streamflyer-core:1.2.0">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/github/rwitzel/streamflyer/streamflyer-core/1.2.0/streamflyer-core-1.2.0.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/com/github/rwitzel/streamflyer/streamflyer-core/1.2.0/streamflyer-core-1.2.0-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/github/rwitzel/streamflyer/streamflyer-core/1.2.0/streamflyer-core-1.2.0-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,7 @@
         <maven-surefire-report-plugin.version>2.18.1</maven-surefire-report-plugin.version>
         <jacoco-maven-plugin.version>0.7.5.201505241946</jacoco-maven-plugin.version>
         <!--  Dependencies [COMPILE]:  -->
+        <streamflyer-core.version>1.2.0</streamflyer-core.version>
         <httpclient.version>4.4.1</httpclient.version>
         <httpcore.version>4.4.1</httpcore.version>
         <commons-logging.version>1.2</commons-logging.version>
@@ -209,6 +210,12 @@
     </distributionManagement>
 
     <dependencies>
+        <dependency>
+            <groupId>com.github.rwitzel.streamflyer</groupId>
+            <artifactId>streamflyer-core</artifactId>
+            <version>${streamflyer-core.version}</version>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>

--- a/src/main/java/microsoft/exchange/webservices/data/core/EwsServiceMultiResponseXmlReader.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/EwsServiceMultiResponseXmlReader.java
@@ -98,8 +98,7 @@ public class EwsServiceMultiResponseXmlReader extends EwsServiceXmlReader {
    * @throws Exception on error
    */
   @Override
-  protected XMLEventReader initializeXmlReader(InputStream stream)
-      throws Exception {
+  protected XMLEventReader initializeXmlReader(InputStream stream, boolean forceXml11) throws Exception {
     return createXmlReader(stream);
   }
 

--- a/src/test/java/microsoft/exchange/webservices/data/core/EwsXmlReader11VersionTest.java
+++ b/src/test/java/microsoft/exchange/webservices/data/core/EwsXmlReader11VersionTest.java
@@ -1,0 +1,55 @@
+package microsoft.exchange.webservices.data.core;
+
+import microsoft.exchange.webservices.data.security.XmlNodeType;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import javax.xml.stream.XMLStreamException;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
+public class EwsXmlReader11VersionTest {
+
+  @Rule public final ExpectedException exception = ExpectedException.none();
+
+  private final String
+      validDocument =
+      "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + "<test>testContent</test>";
+
+  private final String
+      invalidDocument =
+      "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + "<test>test&#x5;Content</test>";
+
+  @Test public void testReadValidDocument() throws Exception {
+    byte[] bytes = validDocument.getBytes(StandardCharsets.UTF_8);
+    EwsXmlReader impl = new EwsXmlReader(new ByteArrayInputStream(bytes), false);
+    impl.read(new XmlNodeType(XmlNodeType.START_DOCUMENT));
+    impl.read(new XmlNodeType(XmlNodeType.START_ELEMENT));
+    String content = impl.readValue();
+    Assert.assertEquals(content, "testContent");
+    impl.read(new XmlNodeType(XmlNodeType.END_DOCUMENT));
+  }
+
+  @Test public void testReadInValidDocumentAsXml10() throws Exception {
+    byte[] bytes = invalidDocument.getBytes(StandardCharsets.UTF_8);
+    EwsXmlReader impl = new EwsXmlReader(new ByteArrayInputStream(bytes), false);
+    impl.read(new XmlNodeType(XmlNodeType.START_DOCUMENT));
+    impl.read(new XmlNodeType(XmlNodeType.START_ELEMENT));
+    exception.expect(XMLStreamException.class);
+    String content = impl.readValue();
+    Assert.assertEquals(content, "test\u0005Content");
+  }
+
+  @Test public void testReadInvalidDocumentAsXml11() throws Exception {
+    byte[] bytes = invalidDocument.getBytes(StandardCharsets.UTF_8);
+    EwsXmlReader impl = new EwsXmlReader(new ByteArrayInputStream(bytes), true);
+    impl.read(new XmlNodeType(XmlNodeType.START_DOCUMENT));
+    impl.read(new XmlNodeType(XmlNodeType.START_ELEMENT));
+    String content = impl.readValue();
+    Assert.assertEquals(content, "test\u0005Content");
+    impl.read(new XmlNodeType(XmlNodeType.END_DOCUMENT));
+  }
+}


### PR DESCRIPTION
Sometimes you have to open XML documents that contain characters that are allowed in XML 1.1 documents but not allowed in XML 1.0 documents. And sometimes you have to open XML documents that contain characters that are entirely forbidden. For these kind of documents some pre-defined modifier exist so that the modified stream can be opened by standard XML parsers:

---
Apply fix from https://github.com/OfficeDev/ews-java-api/pull/409/files