### PR TITLE
SOC-555: Force XML v1.1 preable to avoid parse errors.

### DIFF
--- a/.idea/libraries/Maven__com_github_rwitzel_streamflyer_streamflyer_core_1_2_0.xml
+++ b/.idea/libraries/Maven__com_github_rwitzel_streamflyer_streamflyer_core_1_2_0.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: com.github.rwitzel.streamflyer:streamflyer-core:1.2.0">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/github/rwitzel/streamflyer/streamflyer-core/1.2.0/streamflyer-core-1.2.0.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/com/github/rwitzel/streamflyer/streamflyer-core/1.2.0/streamflyer-core-1.2.0-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/github/rwitzel/streamflyer/streamflyer-core/1.2.0/streamflyer-core-1.2.0-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,7 @@
         <maven-surefire-report-plugin.version>2.18.1</maven-surefire-report-plugin.version>
         <jacoco-maven-plugin.version>0.7.5.201505241946</jacoco-maven-plugin.version>
         <!--  Dependencies [COMPILE]:  -->
+        <streamflyer-core.version>1.2.0</streamflyer-core.version>
         <httpclient.version>4.4.1</httpclient.version>
         <httpcore.version>4.4.1</httpcore.version>
         <commons-logging.version>1.2</commons-logging.version>
@@ -209,6 +210,12 @@
     </distributionManagement>
 
     <dependencies>
+        <dependency>
+            <groupId>com.github.rwitzel.streamflyer</groupId>
+            <artifactId>streamflyer-core</artifactId>
+            <version>${streamflyer-core.version}</version>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>

--- a/src/main/java/microsoft/exchange/webservices/data/autodiscover/AutodiscoverService.java
+++ b/src/main/java/microsoft/exchange/webservices/data/autodiscover/AutodiscoverService.java
@@ -27,8 +27,11 @@ import microsoft.exchange.webservices.data.autodiscover.configuration.Configurat
 import microsoft.exchange.webservices.data.autodiscover.configuration.outlook.OutlookConfigurationSettings;
 import microsoft.exchange.webservices.data.autodiscover.enumeration.AutodiscoverEndpoints;
 import microsoft.exchange.webservices.data.autodiscover.enumeration.AutodiscoverErrorCode;
+import microsoft.exchange.webservices.data.autodiscover.enumeration.DomainSettingName;
+import microsoft.exchange.webservices.data.autodiscover.enumeration.UserSettingName;
 import microsoft.exchange.webservices.data.autodiscover.exception.AutodiscoverLocalException;
 import microsoft.exchange.webservices.data.autodiscover.exception.AutodiscoverRemoteException;
+import microsoft.exchange.webservices.data.autodiscover.exception.MaximumRedirectionHopsExceededException;
 import microsoft.exchange.webservices.data.autodiscover.request.AutodiscoverRequest;
 import microsoft.exchange.webservices.data.autodiscover.request.GetDomainSettingsRequest;
 import microsoft.exchange.webservices.data.autodiscover.request.GetUserSettingsRequest;
@@ -39,20 +42,17 @@ import microsoft.exchange.webservices.data.autodiscover.response.GetUserSettings
 import microsoft.exchange.webservices.data.core.EwsUtilities;
 import microsoft.exchange.webservices.data.core.EwsXmlReader;
 import microsoft.exchange.webservices.data.core.ExchangeServiceBase;
-import microsoft.exchange.webservices.data.core.request.HttpClientWebRequest;
-import microsoft.exchange.webservices.data.core.request.HttpWebRequest;
-import microsoft.exchange.webservices.data.credential.WSSecurityBasedCredentials;
-import microsoft.exchange.webservices.data.autodiscover.enumeration.DomainSettingName;
 import microsoft.exchange.webservices.data.core.enumeration.misc.ExchangeVersion;
 import microsoft.exchange.webservices.data.core.enumeration.misc.TraceFlags;
-import microsoft.exchange.webservices.data.autodiscover.enumeration.UserSettingName;
-import microsoft.exchange.webservices.data.core.exception.misc.ArgumentException;
 import microsoft.exchange.webservices.data.core.exception.http.EWSHttpException;
+import microsoft.exchange.webservices.data.core.exception.misc.ArgumentException;
 import microsoft.exchange.webservices.data.core.exception.misc.FormatException;
-import microsoft.exchange.webservices.data.autodiscover.exception.MaximumRedirectionHopsExceededException;
 import microsoft.exchange.webservices.data.core.exception.service.local.ServiceLocalException;
 import microsoft.exchange.webservices.data.core.exception.service.local.ServiceValidationException;
 import microsoft.exchange.webservices.data.core.exception.service.local.ServiceVersionException;
+import microsoft.exchange.webservices.data.core.request.HttpClientWebRequest;
+import microsoft.exchange.webservices.data.core.request.HttpWebRequest;
+import microsoft.exchange.webservices.data.credential.WSSecurityBasedCredentials;
 import microsoft.exchange.webservices.data.misc.OutParam;
 import microsoft.exchange.webservices.data.security.XmlNodeType;
 
@@ -401,6 +401,7 @@ public class AutodiscoverService extends ExchangeServiceBase
 
       request.setRequestMethod("GET");
       request.setAllowAutoRedirect(false);
+      request.setTimeout(getTimeout());
 
       // Do NOT allow authentication as this single request will be made over plain HTTP.
       request.setAllowAuthentication(false);
@@ -1523,6 +1524,7 @@ public class AutodiscoverService extends ExchangeServiceBase
         request.setAllowAutoRedirect(false);
         request.setPreAuthenticate(false);
         request.setUseDefaultCredentials(this.getUseDefaultCredentials());
+        request.setTimeout(getTimeout());
 
         prepareCredentials(request);
 

--- a/src/main/java/microsoft/exchange/webservices/data/core/EwsServiceMultiResponseXmlReader.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/EwsServiceMultiResponseXmlReader.java
@@ -98,7 +98,7 @@ public class EwsServiceMultiResponseXmlReader extends EwsServiceXmlReader {
    * @throws Exception on error
    */
   @Override
-  protected XMLEventReader initializeXmlReader(InputStream stream)
+  protected XMLEventReader initializeXmlReader(InputStream stream, boolean forceXml11)
       throws Exception {
     return createXmlReader(stream);
   }

--- a/src/main/java/microsoft/exchange/webservices/data/core/ExchangeService.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/ExchangeService.java
@@ -3620,6 +3620,7 @@ public class ExchangeService extends ExchangeServiceBase implements IAutodiscove
 
     AutodiscoverService autodiscoverService = new AutodiscoverService(this, requestedServerVersion);
     autodiscoverService.setWebProxy(getWebProxy());
+    autodiscoverService.setTimeout(getTimeout());
 
     autodiscoverService
         .setRedirectionUrlValidationCallback(validateRedirectionUrlCallback);

--- a/src/main/java/microsoft/exchange/webservices/data/core/ExchangeServiceBase.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/ExchangeServiceBase.java
@@ -889,4 +889,8 @@ public abstract class ExchangeServiceBase implements Closeable {
       return ExchangeServiceBase.binarySecret;
     }
   }
+
+  public int getMaximumPoolingConnections() {
+    return maximumPoolingConnections;
+  }
 }

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/ServiceRequestBase.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/ServiceRequestBase.java
@@ -645,7 +645,11 @@ public abstract class ServiceRequestBase<T> {
   protected HttpWebRequest validateAndEmitRequest(OutputStream responseOutputStream) throws Exception {
     this.validate();
 
-    HttpWebRequest request = this.buildEwsHttpWebRequest();
+    final HttpWebRequest
+        request =
+        service.getMaximumPoolingConnections() > 1 ? buildEwsHttpPoolingWebRequest()
+                                                   : buildEwsHttpWebRequest();
+
     request.setResponseOutputStream(responseOutputStream);
 
     try {

--- a/src/main/java/microsoft/exchange/webservices/data/core/service/schema/ContactSchema.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/service/schema/ContactSchema.java
@@ -306,7 +306,7 @@ public class ContactSchema extends ItemSchema {
      * The MSExchangeCertificate.
      */
 
-    String MSExchangeCertificate = "contacts:MSExchageCertificate";
+    String MSExchangeCertificate = "contacts:MSExchangeCertificate";
 
     /**
      * The DirectoryId.

--- a/src/main/java/microsoft/exchange/webservices/data/util/Xml11VersionModifier.java
+++ b/src/main/java/microsoft/exchange/webservices/data/util/Xml11VersionModifier.java
@@ -10,6 +10,11 @@ import java.util.regex.Pattern;
 
 public class Xml11VersionModifier implements Modifier {
 
+  private final static Pattern
+      XML_PROLOG_PATTERN =
+      Pattern.compile("<\\?xml[^>]*version\\s*=\\s*['\"]((1.0)|(1.1))['\"].*");
+
+  private final static Pattern BASE_XML_PROLOG_PATTERN = Pattern.compile("<\\?xml.*");
   //
   // constants
   //
@@ -86,16 +91,14 @@ public class Xml11VersionModifier implements Modifier {
         // (Should we do aware of BOMs here? No. I consider it the
         // responsibility of the caller to provide characters without BOM.)
 
-        Matcher
-            matcher =
-            Pattern.compile("<\\?xml[^>]*version\\s*=\\s*['\"]((1.0)|(1.1))['\"].*").matcher(characterBuffer);
+        Matcher matcher = XML_PROLOG_PATTERN.matcher(characterBuffer);
         if (matcher.matches()) {
 
           // replace version in prolog
           characterBuffer.replace(matcher.start(1), matcher.end(1), xmlVersion);
         } else {
           // is there a prolog that is too long?
-          Matcher matcher2 = Pattern.compile("<\\?xml.*").matcher(characterBuffer);
+          Matcher matcher2 = BASE_XML_PROLOG_PATTERN.matcher(characterBuffer);
           if (matcher2.matches()) {
             // this is not normal at all -> throw exception
             throw new XmlPrologRidiculouslyLongException(characterBuffer.toString());

--- a/src/main/java/microsoft/exchange/webservices/data/util/Xml11VersionModifier.java
+++ b/src/main/java/microsoft/exchange/webservices/data/util/Xml11VersionModifier.java
@@ -1,0 +1,118 @@
+package microsoft.exchange.webservices.data.util;
+
+import com.github.rwitzel.streamflyer.core.AfterModification;
+import com.github.rwitzel.streamflyer.core.Modifier;
+import com.github.rwitzel.streamflyer.util.ModificationFactory;
+import com.github.rwitzel.streamflyer.xml.XmlPrologRidiculouslyLongException;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class Xml11VersionModifier implements Modifier {
+
+  //
+  // constants
+  //
+
+  public final int INITIAL_NUMBER_OF_CHARACTERS = 8192;
+
+
+  private enum Xml11VersionModifierState {
+    /**
+     * The initial state. No input read yet.
+     */
+    INITIAL,
+
+    /**
+     * The modifier has requested to read the XML prolog.
+     */
+    PROLOG_REQUEST,
+
+    /**
+     * The modifier has read the XML prolog, modified it if necessary. Nothing more to do for the modifier.
+     */
+    NO_LONGER_MODIFYING
+  }
+
+  //
+  // injected properties
+  //
+
+  protected ModificationFactory factory;
+
+  protected String xmlVersion;
+
+  //
+  // properties that represent the mutable state
+  //
+
+  private Xml11VersionModifierState state = Xml11VersionModifierState.INITIAL;
+
+  //
+  // constructors
+  //
+
+  public Xml11VersionModifier() {
+
+    this.factory = new ModificationFactory(0, INITIAL_NUMBER_OF_CHARACTERS);
+    this.xmlVersion = "1.1";
+  }
+
+  //
+  // Modifier.* methods
+  //
+
+  /**
+   * @see com.github.rwitzel.streamflyer.core.Modifier#modify(java.lang.StringBuilder, int, boolean)
+   */
+  @Override public AfterModification modify(StringBuilder characterBuffer,
+      int firstModifiableCharacterInBuffer, boolean endOfStreamHit) {
+
+    switch (state) {
+
+      case NO_LONGER_MODIFYING:
+
+        return factory.skipEntireBuffer(characterBuffer, firstModifiableCharacterInBuffer, endOfStreamHit);
+
+      case INITIAL:
+
+        state = Xml11VersionModifierState.PROLOG_REQUEST;
+
+        // you never know how many whitespace characters are in the prolog
+        return factory.modifyAgainImmediately(INITIAL_NUMBER_OF_CHARACTERS, firstModifiableCharacterInBuffer);
+
+      case PROLOG_REQUEST:
+
+        // (Should we do aware of BOMs here? No. I consider it the
+        // responsibility of the caller to provide characters without BOM.)
+
+        Matcher
+            matcher =
+            Pattern.compile("<\\?xml[^>]*version\\s*=\\s*['\"]((1.0)|(1.1))['\"].*").matcher(characterBuffer);
+        if (matcher.matches()) {
+
+          // replace version in prolog
+          characterBuffer.replace(matcher.start(1), matcher.end(1), xmlVersion);
+        } else {
+          // is there a prolog that is too long?
+          Matcher matcher2 = Pattern.compile("<\\?xml.*").matcher(characterBuffer);
+          if (matcher2.matches()) {
+            // this is not normal at all -> throw exception
+            throw new XmlPrologRidiculouslyLongException(characterBuffer.toString());
+          }
+
+          // insert prolog
+          characterBuffer.insert(0, "<?xml version='" + xmlVersion + "'?>");
+        }
+
+        state = Xml11VersionModifierState.NO_LONGER_MODIFYING;
+
+        return factory.skipEntireBuffer(characterBuffer, firstModifiableCharacterInBuffer, endOfStreamHit);
+
+      default:
+        throw new IllegalStateException("state " + state + " not supported");
+
+    }
+
+  }
+}

--- a/src/test/java/microsoft/exchange/webservices/data/core/EwsXmlWithInvalidCharactersReaderTest.java
+++ b/src/test/java/microsoft/exchange/webservices/data/core/EwsXmlWithInvalidCharactersReaderTest.java
@@ -1,0 +1,88 @@
+/*
+ * The MIT License
+ * Copyright (c) 2012 Microsoft Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package microsoft.exchange.webservices.data.core;
+
+import microsoft.exchange.webservices.data.security.XmlNodeType;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import javax.xml.stream.XMLStreamException;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
+public class EwsXmlWithInvalidCharactersReaderTest {
+
+  @Rule public final ExpectedException exception = ExpectedException.none();
+
+  private final String
+      validDocument =
+      "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + "<test>testContent</test>";
+
+  private final String
+      invalidDocument =
+      "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + "<test>test&#x5;Content</test>";
+
+  @Test public void testReadValidDocumentXml10() throws Exception {
+    byte[] bytes = validDocument.getBytes(StandardCharsets.UTF_8);
+    EwsXmlReader impl = new EwsXmlReader(new ByteArrayInputStream(bytes), false);
+    impl.read(new XmlNodeType(XmlNodeType.START_DOCUMENT));
+    impl.read(new XmlNodeType(XmlNodeType.START_ELEMENT));
+    String content = impl.readValue();
+    Assert.assertEquals(content, "testContent");
+    impl.read(new XmlNodeType(XmlNodeType.END_DOCUMENT));
+  }
+
+  @Test public void testReadInValidDocumentAsXml10() throws Exception {
+    byte[] bytes = invalidDocument.getBytes(StandardCharsets.UTF_8);
+    EwsXmlReader impl = new EwsXmlReader(new ByteArrayInputStream(bytes), false);
+    impl.read(new XmlNodeType(XmlNodeType.START_DOCUMENT));
+    impl.read(new XmlNodeType(XmlNodeType.START_ELEMENT));
+    exception.expect(XMLStreamException.class);
+
+    impl.readValue();
+  }
+
+  @Test public void testReadInvalidDocumentAsXml11() throws Exception {
+    byte[] bytes = invalidDocument.getBytes("UTF-8");
+    EwsXmlReader impl = new EwsXmlReader(new ByteArrayInputStream(bytes), true);
+    impl.read(new XmlNodeType(XmlNodeType.START_DOCUMENT));
+    impl.read(new XmlNodeType(XmlNodeType.START_ELEMENT));
+    String content = impl.readValue();
+    Assert.assertEquals(content, "test\u0005Content");
+    impl.read(new XmlNodeType(XmlNodeType.END_DOCUMENT));
+  }
+
+  @Test public void testReadValidDocumentXml11() throws Exception {
+    byte[] bytes = validDocument.getBytes(StandardCharsets.UTF_8);
+    EwsXmlReader impl = new EwsXmlReader(new ByteArrayInputStream(bytes), true);
+    impl.read(new XmlNodeType(XmlNodeType.START_DOCUMENT));
+    impl.read(new XmlNodeType(XmlNodeType.START_ELEMENT));
+    String content = impl.readValue();
+    Assert.assertEquals(content, "testContent");
+    impl.read(new XmlNodeType(XmlNodeType.END_DOCUMENT));
+  }
+}


### PR DESCRIPTION
Sometimes you have to open XML documents that contain characters that are allowed in XML 1.1 documents but not allowed in XML 1.0 documents. And sometimes you have to open XML documents that contain characters that are entirely forbidden. For these kind of documents some pre-defined modifier exist so that the modified stream can be opened by standard XML parsers:

---
Apply fix from https://github.com/OfficeDev/ews-java-api/pull/409/files