### PR TITLE
SOC-1234: Start work with stream in MimeContent instead of byte array.

### DIFF
--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/MimeContent.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/MimeContent.java
@@ -23,11 +23,6 @@
 
 package microsoft.exchange.webservices.data.property.complex;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import javax.xml.stream.XMLStreamException;
 import microsoft.exchange.webservices.data.core.EwsServiceXmlReader;
 import microsoft.exchange.webservices.data.core.EwsServiceXmlWriter;
 import microsoft.exchange.webservices.data.core.XmlAttributeNames;
@@ -36,15 +31,17 @@ import microsoft.exchange.webservices.data.core.exception.service.local.ServiceX
 import microsoft.exchange.webservices.data.util.FileUtils;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+
+import javax.xml.stream.XMLStreamException;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 
 /**
  * Represents the MIME content of an item.
  */
 public final class MimeContent extends ComplexProperty {
-
-  private static final Log LOG = LogFactory.getLog(MimeContent.class);
 
   /**
    * The character set.
@@ -160,20 +157,7 @@ public final class MimeContent extends ComplexProperty {
    * @return the content
    */
   public byte[] getContent() {
-    if (contentReader != null) {
-      final ByteArrayOutputStream output = new ByteArrayOutputStream(4096);
-      try {
-        FileUtils.copyLarge(contentReader, output);
-      } catch (Exception e) {
-        LOG.warn("An error occurred during copying file", e);
-      } finally {
-        IOUtils.closeQuietly(output);
-      }
-
-      return output.toByteArray();
-    }
-
-    return null;
+    return FileUtils.getBytes(contentReader);
   }
 
   /**

--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/MimeContent.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/MimeContent.java
@@ -137,7 +137,7 @@ public final class MimeContent extends ComplexProperty {
   }
 
   /**
-   * Gets L the character set of the content.
+   * Gets the character set of the content.
    *
    * @return the character set
    */
@@ -155,7 +155,7 @@ public final class MimeContent extends ComplexProperty {
   }
 
   /**
-   * Gets  the character set of the content.
+   * Gets the character set of the content.
    *
    * @return the content
    */

--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/MimeContent.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/MimeContent.java
@@ -36,11 +36,15 @@ import microsoft.exchange.webservices.data.core.exception.service.local.ServiceX
 import microsoft.exchange.webservices.data.util.FileUtils;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 /**
  * Represents the MIME content of an item.
  */
 public final class MimeContent extends ComplexProperty {
+
+  private static final Log LOG = LogFactory.getLog(MimeContent.class);
 
   /**
    * The character set.
@@ -133,7 +137,7 @@ public final class MimeContent extends ComplexProperty {
   }
 
   /**
-   * Gets  the character set of the content.
+   * Gets L the character set of the content.
    *
    * @return the character set
    */
@@ -161,7 +165,7 @@ public final class MimeContent extends ComplexProperty {
       try {
         FileUtils.copyLarge(contentReader, output);
       } catch (Exception e) {
-        e.printStackTrace();
+        LOG.warn("An error occurred during copying file", e);
       } finally {
         IOUtils.closeQuietly(output);
       }

--- a/src/main/java/microsoft/exchange/webservices/data/util/FileUtils.java
+++ b/src/main/java/microsoft/exchange/webservices/data/util/FileUtils.java
@@ -34,7 +34,7 @@ public final class FileUtils {
 
   public static byte[] getBytes(final InputStream input) {
     if (input != null) {
-      final ByteArrayOutputStream output = new ByteArrayOutputStream(4096);
+      final ByteArrayOutputStream output = new ByteArrayOutputStream(DEFAULT_BUFFER_SIZE);
       try {
         FileUtils.copyLarge(input, output);
       } catch (Exception e) {

--- a/src/main/java/microsoft/exchange/webservices/data/util/FileUtils.java
+++ b/src/main/java/microsoft/exchange/webservices/data/util/FileUtils.java
@@ -1,0 +1,27 @@
+package microsoft.exchange.webservices.data.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+public final class FileUtils {
+
+  private static final int DEFAULT_BUFFER_SIZE = 1024 * 4;
+  private static final int EOF = -1;
+
+  private FileUtils() {}
+
+  public static long copyLarge(final InputStream input, final OutputStream output) throws IOException {
+    return copyLarge(input, output, new byte[DEFAULT_BUFFER_SIZE]);
+  }
+
+  public static long copyLarge(InputStream input, OutputStream output, byte[] buffer) throws IOException {
+    long count = 0;
+    int n = 0;
+    while (EOF != (n = input.read(buffer))) {
+      output.write(buffer, 0, n);
+      count += n;
+    }
+    return count;
+  }
+}

--- a/src/main/java/microsoft/exchange/webservices/data/util/FileUtils.java
+++ b/src/main/java/microsoft/exchange/webservices/data/util/FileUtils.java
@@ -1,10 +1,17 @@
 package microsoft.exchange.webservices.data.util;
 
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
 public final class FileUtils {
+
+  private static final Log LOG = LogFactory.getLog(FileUtils.class);
 
   private static final int DEFAULT_BUFFER_SIZE = 1024 * 4;
   private static final int EOF = -1;
@@ -23,5 +30,22 @@ public final class FileUtils {
       count += n;
     }
     return count;
+  }
+
+  public static byte[] getBytes(final InputStream input) {
+    if (input != null) {
+      final ByteArrayOutputStream output = new ByteArrayOutputStream(4096);
+      try {
+        FileUtils.copyLarge(input, output);
+      } catch (Exception e) {
+        LOG.warn("An error occurred during copying file", e);
+      } finally {
+        IOUtils.closeQuietly(output);
+      }
+
+      return output.toByteArray();
+    }
+
+    return null;
   }
 }


### PR DESCRIPTION
Potential problems with OOM during work with attachments.

---

We should not store file attachment content as a byte array, we should work with the stream.