### PR TITLE
SOC-3294 <Create /> causes an error in processing

### DIFF
--- a/src/main/java/microsoft/exchange/webservices/data/core/response/SyncResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/response/SyncResponse.java
@@ -123,44 +123,44 @@ public abstract class SyncResponse<TServiceObject extends ServiceObject,
 
           if (change != null) {
             reader.read();
-            reader.ensureCurrentNodeIsStartElement();
-
-            if (change.getChangeType().equals(ChangeType.Delete)
+            if (reader.isStartElement()) {
+              if (change.getChangeType().equals(ChangeType.Delete)
                 || change.getChangeType().equals(ChangeType.ReadFlagChange)) {
-              change.setId(change.createId());
-              change.getId().loadFromXml(reader,
+                change.setId(change.createId());
+                change.getId().loadFromXml(reader,
                   change.getId().getXmlElementName());
 
-              if (change.getChangeType().equals(ChangeType.ReadFlagChange)) {
-                reader.read();
-                reader.ensureCurrentNodeIsStartElement();
-                ItemChange itemChange = null;
-                if (change instanceof ItemChange) {
-                  itemChange = (ItemChange) change;
-                }
-                EwsUtilities
+                if (change.getChangeType().equals(ChangeType.ReadFlagChange)) {
+                  reader.read();
+                  reader.ensureCurrentNodeIsStartElement();
+                  ItemChange itemChange = null;
+                  if (change instanceof ItemChange) {
+                    itemChange = (ItemChange) change;
+                  }
+                  EwsUtilities
                     .ewsAssert(itemChange != null, "SyncResponse." + "ReadElementsFromXml",
-                               "ReadFlagChange is only " + "valid on ItemChange");
+                      "ReadFlagChange is only " + "valid on ItemChange");
 
-                itemChange.setIsRead(reader.readElementValue(
+                  itemChange.setIsRead(reader.readElementValue(
                     Boolean.class, XmlNamespace.Types,
                     XmlElementNames.IsRead));
-              }
-            } else {
+                }
+              } else {
 
-              change.setServiceObject(EwsUtilities
+                change.setServiceObject(EwsUtilities
                   .createEwsObjectFromXmlElementName(null,
-                      reader.getService(), reader.getLocalName()));
+                    reader.getService(), reader.getLocalName()));
 
-              change.getServiceObject().loadFromXml(reader,
+                change.getServiceObject().loadFromXml(reader,
                   true, /* clearPropertyBag */
                   this.propertySet, this.getSummaryPropertiesOnly());
-            }
+              }
 
-            reader.readEndElementIfNecessary(XmlNamespace.Types,
+              reader.readEndElementIfNecessary(XmlNamespace.Types,
                 change.getChangeType().toString());
 
-            this.changes.add(change);
+              this.changes.add(change);
+            }
           }
         }
       } while (!reader.isEndElement(XmlNamespace.Messages,


### PR DESCRIPTION
In current implementation the next node throws an error
```
	<t:Create>
							<t:MeetingRequest>
								<t:ItemId
									Id="AAMkAGZlMDRhMzQyLTVlZDAtNDY3Yy05YWFmLWQzN2JiY2NkM2FkYQBGAAAAAABE/CYN2VSfSbP9W6jwV5seBwCQEKM3pEPBR5uoW2WV3tUwAAAAAAELAADwmtvPcI1WSpUp9oOJ4hELAAgJtCXXAAA="
									ChangeKey="CwAAABYAAADwmtvPcI1WSpUp9oOJ4hELAAgGxHj5"/>
								<t:ItemClass>IPM.Schedule.Meeting.Request</t:ItemClass>
							</t:MeetingRequest>
						</t:Create>
						<t:Create/>
```
Empty content of <create> node is prohibited
In new implementation we will just skip this messages